### PR TITLE
GRE-3084 Fix bug with "manual review needed" label creation

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -40,7 +40,7 @@ jobs:
           # Create "manual review needed" label if it doesn't exist
           if ! gh label list --json name | grep -q "manual review needed"; then
             gh label create \
-              manual review needed \
+              "manual review needed" \
               --description "Indicates that the Dependabot PR requires a manual review, e.g., because of a major update" \
               --color DE9DA2
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ using the prefix _INTERNAL:_ (see [this](https://github.com/olivierlacan/keep-a-
 
 <!-- List the changes in your PR under the Unreleased title. You can also copy this list to your PR summary. -->
 
+## <a name="1.2.1"/>[1.2.1] - 2022-11-11
+
+### Fixed
+
+- The automatic creation of the `manual review needed` label failing with the error "too many arguments" caused by
+  missing double quotes.
+
 ## <a name="1.2.0"/>[1.2.0] - 2022-11-10
 
 ### Added
@@ -53,6 +60,7 @@ API changes.
   requests making it easier to reuse these common workflows without having to duplicate them in each using repository.
   For more information, see the [Provided reusable workflows](README.md#provided-reusable-workflows) in the README.
 
+[1.2.1]: https://github.com/helkasko/asti-github-workflows/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/helkasko/asti-github-workflows/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/helkasko/asti-github-workflows/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/helkasko/asti-github-workflows/releases/tag/v1.0.0


### PR DESCRIPTION
## Description

[GRE-3084]

### Fixed

- The automatic creation of the `manual review needed` label failing with the error "too many arguments" caused by missing double quotes.

___

- [ ] Produced code passes tests
- [ ] Code builds without errors
- [ ] Unit tests written and passing

  * Clear and easy to understand
  * Reliable that they fail if a bug is in the system
  * Fast (slow tests will be a nuisance in numbers)
        
- [ ] Code is documented

    * When doing public API functionality context of the code is written
    * Clarification, when code might be unclear.
    * Clear and well named functionality does not need a comment
      
- [ ] Variable names convey their use case
- [ ] Produced code matches presumed functionality

    * Matches specifications given in the issue
    * Works in desired environments
      
- [ ] Code quality

    * Code follows best practices
      * Usually specified by the language, framework or library itself.
    * Code follows styleguide
    * Project specific linter rules
      * If no linting rules are specified each project should follow some kind of guidelines for unified code
        
- [ ] Functionality verified by testing the application
- [ ] Each function and class should have a single clear purpose

    * Complex or long function sections should be split into smaller ones
    * Each additional **if**, **loop**, **switch** and **logical conditional operation** adds complexity
    * Complexity can be measured by this way if each complexity point is added together.


[GRE-3084]: https://kaskodev.atlassian.net/browse/GRE-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ