### PR TITLE
GRE-3090 Fix workflows failing when pushing custom changes to a Dependabot PR

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -13,8 +13,11 @@ on:
 jobs:
   approve-pr:
     runs-on: ubuntu-latest
-    # Checking the author will prevent the action run failing on non-Dependabot PRs
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # Checking the workflow triggerer will prevent the workflow run failing on non-Dependabot commits and PRs. Checking
+    # the PR author isn't sufficient since it might be necessary to push commits to a Dependabot PR. In that case, it's
+    # best to skip running this workflow since the original Dependabot PR has been edited and it might be reasonable to
+    # do a manual approval of the custom changes.
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -15,7 +15,13 @@ on:
 jobs:
   label-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # Checking the workflow triggerer will prevent the workflow run failing on non-Dependabot commits and PRs. Checking
+    # the PR author isn't sufficient since it might be necessary to push commits to a Dependabot PR. In that case, we
+    # can skip running the workflow since the workflow should've been run already once for the Dependabot PR and
+    # rerunning it isn't necessary if there are any custom changes. Running this workflow for other than Dependabot's
+    # commits would also require adding the given personal access token secret to the action's secrets instead of the
+    # Dependabot secrets.
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,13 @@ on:
 jobs:
   merge-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # Checking the workflow triggerer will prevent the workflow run failing on non-Dependabot commits and PRs. Checking
+    # the PR author isn't sufficient since it might be necessary to push commits to a Dependabot PR. In that case, it's
+    # best to skip running this workflow since the original Dependabot PR has been edited and it might be reasonable to
+    # do a manual merge of the Dependabot PR with the custom changes. Running this workflow for other than Dependabot's
+    # commits would also require adding the given personal access token secret to the action's secrets instead of the
+    # Dependabot secrets.
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ using the prefix _INTERNAL:_ (see [this](https://github.com/olivierlacan/keep-a-
 
 <!-- List the changes in your PR under the Unreleased title. You can also copy this list to your PR summary. -->
 
+### Fixed
+
+- The `Dependabot auto-label` and `Dependabot auto-merge` workflows failing when pushing custom changes to a Dependabot
+  PR.
+
+  These two workflows rely on the given personal access token (PAT) and if the PAT has only been defined in the
+  Dependabot secrets, any workflow runs triggered by other than Dependabot don't have access to the PAT resulting in the
+  workflows failing. One option would be to define the PAT in the action secrets so that all workflow runs would have
+  access to the secret regardless of who triggered the workflows.
+
+  However, when there are custom changes to a Dependabot PR it might be more reasonable to skip running the workflows
+  altogether. For instance, in that case, it might be more reasonable to require a manual approval and merge of the
+  Dependabot PR. Also, it's unnecessary to run the `Dependabot auto-label` workflow since it should've been run already
+  the first time the PR was created.
+
+  So, the issue has been fixed by skipping the workflows for any custom commits in a Dependabot PR. This has been
+  achieved by checking the workflow triggerer instead of the pull request author when deciding whether the workflow
+  should be run.
+
 ## <a name="1.2.1"/>[1.2.1] - 2022-11-11
 
 ### Fixed


### PR DESCRIPTION
## Description

[GRE-3090]

### Fixed

- The `Dependabot auto-label` and `Dependabot auto-merge` workflows failing when pushing custom changes to a Dependabot PR.

  These two workflows rely on the given personal access token (PAT) and if the PAT has only been defined in the Dependabot secrets, any workflow runs triggered by other than Dependabot don't have access to the PAT resulting in the workflows failing. One option would be to define the PAT in the action secrets so that all workflow runs would have access to the secret regardless of who triggered the workflows.

  However, when there are custom changes to a Dependabot PR it might be more reasonable to skip running the workflows altogether. For instance, in that case, it might be more reasonable to require a manual approval and merge of the Dependabot PR. Also, it's unnecessary to run the `Dependabot auto-label` workflow since it should've been run already the first time the PR was created.

  So, the issue has been fixed by skipping the workflows for any custom commits in a Dependabot PR. This has been achieved by checking the workflow triggerer instead of the pull request author when deciding whether the workflow should be run.

## Testing instructions

These changes have been tested using the `asti-black-internal-back` repository by pushing a custom commit to [a Dependabot PR](https://github.com/helkasko/asti-black-internal-back/pull/25). As can be seen from the PR, the `Dependabot auto-approve`, `Dependabot auto-merge`, and `Dependabot auto-label` workflows have been skipped for the custom commit.

___

- [ ] Produced code passes tests
- [ ] Code builds without errors
- [ ] Unit tests written and passing

  * Clear and easy to understand
  * Reliable that they fail if a bug is in the system
  * Fast (slow tests will be a nuisance in numbers)
        
- [ ] Code is documented

    * When doing public API functionality context of the code is written
    * Clarification, when code might be unclear.
    * Clear and well named functionality does not need a comment
      
- [ ] Variable names convey their use case
- [ ] Produced code matches presumed functionality

    * Matches specifications given in the issue
    * Works in desired environments
      
- [ ] Code quality

    * Code follows best practices
      * Usually specified by the language, framework or library itself.
    * Code follows styleguide
    * Project specific linter rules
      * If no linting rules are specified each project should follow some kind of guidelines for unified code
        
- [ ] Functionality verified by testing the application
- [ ] Each function and class should have a single clear purpose

    * Complex or long function sections should be split into smaller ones
    * Each additional **if**, **loop**, **switch** and **logical conditional operation** adds complexity
    * Complexity can be measured by this way if each complexity point is added together.


[GRE-3090]: https://kaskodev.atlassian.net/browse/GRE-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ