### PR TITLE
GRE-3087 Add reusable workflow for submitting Gradle dependencies to GitHub Dependency Submission API

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,49 @@
+# This reusable GitHub workflow is used to calculate the dependencies for a Gradle project and submit the dependency
+# list to the GitHub Dependency Submission API in order to get Dependabot security alerts for the dependencies.
+#
+# GitHub's dependency graph uses static analysis to scan the dependencies from manifest files or lockfiles in
+# repositories. However, for some ecosystems and tools such as Gradle the dependencies cannot reliably be parsed
+# statically. As such, the GitHub dependency graph doesn't support these kinds of package ecosystems. For a list of
+# supported package ecosystems, see https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems.
+#
+# Since the dependency graph is used as a basis for detecting vulnerable dependencies, it hasn't previously been
+# possible to get Dependabot security alerts for unsupported package ecosystems. However, GitHub has now added a new
+# Dependency Submission API which allows submitting the dynamically calculated dependency list to GitHub's dependency
+# graph. Thus, this workflow utilizes the gradle-dependency-submission action to submit the dependencies of a Gradle
+# project to the GitHub dependency graph.
+#
+# For more information, see
+# - https://github.blog/2022-06-17-creating-comprehensive-dependency-graph-build-time-detection/
+# - https://github.com/mikepenz/gradle-dependency-submission
+#
+# Adapted from: https://github.com/mikepenz/gradle-dependency-submission#configure-the-workflow
+name: Submit Gradle Dependencies
+on:
+  workflow_call:
+    secrets:
+      registry-url:
+        description: "The URL for the private Maven package registry"
+        required: true
+      registry-username:
+        description: "The username for the private Maven package registry"
+        required: true
+      registry-password:
+        description: "The password for the private Maven package registry"
+        required: true
+
+jobs:
+  submit-gradle-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Gradle Dependency Submission action
+        uses: mikepenz/gradle-dependency-submission@v0.8.3
+        with:
+          gradle-project-path: '.'
+          gradle-build-module: ':'
+        env:
+          # Set the registry credentials as environment variables.
+          # See: https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties
+          ORG_GRADLE_PROJECT_nexusUrl: ${{ secrets.registry-url }}
+          ORG_GRADLE_PROJECT_repoUser: ${{ secrets.registry-username }}
+          ORG_GRADLE_PROJECT_repoPassword: ${{ secrets.registry-password }}

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,20 +1,6 @@
-# This reusable GitHub workflow is used to calculate the dependencies for a Gradle project and submit the dependency
-# list to the GitHub Dependency Submission API in order to get Dependabot security alerts for the dependencies.
-#
-# GitHub's dependency graph uses static analysis to scan the dependencies from manifest files or lockfiles in
-# repositories. However, for some ecosystems and tools such as Gradle the dependencies cannot reliably be parsed
-# statically. As such, the GitHub dependency graph doesn't support these kinds of package ecosystems. For a list of
-# supported package ecosystems, see https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems.
-#
-# Since the dependency graph is used as a basis for detecting vulnerable dependencies, it hasn't previously been
-# possible to get Dependabot security alerts for unsupported package ecosystems. However, GitHub has now added a new
-# Dependency Submission API which allows submitting the dynamically calculated dependency list to GitHub's dependency
-# graph. Thus, this workflow utilizes the gradle-dependency-submission action to submit the dependencies of a Gradle
-# project to the GitHub dependency graph.
-#
-# For more information, see
-# - https://github.blog/2022-06-17-creating-comprehensive-dependency-graph-build-time-detection/
-# - https://github.com/mikepenz/gradle-dependency-submission
+# This reusable GitHub workflow is used to calculate the dependencies for a Gradle project and submit the resulting
+# dependency list to the GitHub Dependency Submission API in order to get Dependabot security alerts for the
+# dependencies.
 #
 # Adapted from: https://github.com/mikepenz/gradle-dependency-submission#configure-the-workflow
 name: Submit Gradle Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ using the prefix _INTERNAL:_ (see [this](https://github.com/olivierlacan/keep-a-
 
 <!-- List the changes in your PR under the Unreleased title. You can also copy this list to your PR summary. -->
 
+### Added
+
+- A new reusable GitHub workflow for calculating the dependencies for a Gradle project and submitting the resulting
+  dependency list to the GitHub Dependency Submission API in order to get Dependabot security alerts for the
+  dependencies. For more information, see the [Provided reusable workflows](README.md#provided-reusable-workflows) in
+  the README.
+
 ## <a name="1.2.2"/>[1.2.2] - 2022-11-16
 
 ### Fixed


### PR DESCRIPTION
## Description

[GRE-3087]

### Added

- A new reusable GitHub workflow for calculating the dependencies for a Gradle project and submitting the resulting dependency list to the GitHub Dependency Submission API in order to get Dependabot security alerts for the dependencies. For more information, see the [Provided reusable workflows](README.md#provided-reusable-workflows) in the README.

___

- [ ] Produced code passes tests
- [ ] Code builds without errors
- [ ] Unit tests written and passing

  * Clear and easy to understand
  * Reliable that they fail if a bug is in the system
  * Fast (slow tests will be a nuisance in numbers)
        
- [ ] Code is documented

    * When doing public API functionality context of the code is written
    * Clarification, when code might be unclear.
    * Clear and well named functionality does not need a comment
      
- [ ] Variable names convey their use case
- [ ] Produced code matches presumed functionality

    * Matches specifications given in the issue
    * Works in desired environments
      
- [ ] Code quality

    * Code follows best practices
      * Usually specified by the language, framework or library itself.
    * Code follows styleguide
    * Project specific linter rules
      * If no linting rules are specified each project should follow some kind of guidelines for unified code
        
- [ ] Functionality verified by testing the application
- [ ] Each function and class should have a single clear purpose

    * Complex or long function sections should be split into smaller ones
    * Each additional **if**, **loop**, **switch** and **logical conditional operation** adds complexity
    * Complexity can be measured by this way if each complexity point is added together.


[GRE-3087]: https://kaskodev.atlassian.net/browse/GRE-3087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ